### PR TITLE
EntitySubscription Limit Clause

### DIFF
--- a/src/classes/Milestone1_Task_Chatter_Tst.cls
+++ b/src/classes/Milestone1_Task_Chatter_Tst.cls
@@ -31,6 +31,67 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
 @isTest
 private class Milestone1_Task_Chatter_Tst 
 {
+	
+    static private Milestone1_Project__c testProject = Milestone1_Test_Utility.sampleProject('UNIT TEST PROJECT NAME ABC123XYZ UNIQUE' + System.now());
+	
+	/****************************************************************************************************
+    /*  Author:   Passage Technology (www.passagetech.com)                      						*
+    /*  Test:    nonAllDataUser(): Verifies that a user that does not have the View/Modify all			*
+    /*				permissions may update the task.													*
+    /*  Issue:    https://github.com/ForceDotComLabs/Milestones-PM/issues/75							*
+    /****************************************************************************************************/         
+	
+    static testMethod void nonAllDataUser()
+    { 
+	    Profile profileUsed;
+	    User userObj;
+	    
+        if(!Milestone1_Schema_Helper.isOrgChatterEnabled())
+            return; //chatter is disabled - we can't run this test. 	    
+	        
+        //Setup project information
+        insert testProject;
+	    Milestone1_Milestone__c testMilestone = Milestone1_Test_Utility.sampleMilestone(testProject.Id,null,'UNIT TEST MILESTONE NAME ACB123XYZ UNIQUE' + System.now());
+        insert testMilestone;
+        
+        //Create a non-admin user
+        for( Profile p : [ Select Id, PermissionsViewAllData, Name from Profile 
+        					where userLicense.licenseDefinitionKey = 'SFDC' 
+        					AND PermissionsViewAllData = false
+        					AND PermissionsModifyAllData = false] ){
+             profileUsed = p;
+             break;
+        }
+        
+        userObj = Milestone1_Test_Utility.createSFUser(profileUsed);
+        system.debug('user Id for test ' + userObj.Id);
+        
+        Test.startTest();
+        System.runAs(userObj) {
+			Milestone1_Settings__c settings = Milestone1_Test_Utility.createDefaultCustomChatterSettings(true);
+	        System.assert(settings.Auto_Follow_Task__c, 'Auto Follow Task must be true for this test to work.');
+        		        
+	        Milestone1_Task__c testTask = Milestone1_Test_Utility.sampleTask(testMilestone.Id);
+	        testTask.Assigned_To__c = userObj.Id;
+	        testTask.Complete__c = false;
+	        insert testTask;
+	        
+	        sObject subscription = Database.query('Select Id, ParentId, SubscriberId from EntitySubscription where ParentId = \'' + testTask.Id + '\' LIMIT 1000');
+	        //assert that the user is following this object
+	        system.assertEquals(userObj.Id,(id) subscription.get('SubscriberId'));
+	        
+	        testTask.Complete__c = true;
+	        update testTask;
+	        
+	        List<sObject> subscriptionList = Database.query('Select Id, ParentId, SubscriberId from EntitySubscription where ParentId = \''+testTask.Id+'\' LIMIT 1000');
+	        //assert that no one is following this object after its marked as complete
+	        system.assertEquals(0,subscriptionList.size());
+        }
+        Test.stopTest();
+
+        
+    }
+
     static testMethod void testChatterTaskFollows()
     { 
         if(!Milestone1_Schema_Helper.isOrgChatterEnabled())
@@ -40,14 +101,11 @@ private class Milestone1_Task_Chatter_Tst
         User userObj = Milestone1_Test_Utility.createSFUser();
         
         System.runAs(userObj) {
-        
-	        Milestone1_Settings__c settings = Milestone1_Test_Utility.createDefaultCustomChatterSettings(true);
+			Milestone1_Settings__c settings = Milestone1_Test_Utility.createDefaultCustomChatterSettings(true);        
 	        System.assert(settings.Auto_Follow_Task__c, 'Auto Follow Task must be true for this test to work.');
 	        
-	        Milestone1_Project__c testProject = Milestone1_Test_Utility.sampleProject('UNIT TEST PROJECT NAME ABC123XYZ UNIQUE' + System.now());
-	        insert testProject;
-	        
-	        Milestone1_Milestone__c testMilestone = Milestone1_Test_Utility.sampleMilestone(testProject.Id,null,'UNIT TEST MILESTONE NAME ACB123XYZ UNIQUE' + System.now());
+	        insert testProject;	        
+    		Milestone1_Milestone__c testMilestone = Milestone1_Test_Utility.sampleMilestone(testProject.Id,null,'UNIT TEST MILESTONE NAME ACB123XYZ UNIQUE' + System.now());
 	        insert testMilestone;
 	
 	        Milestone1_Task__c testTask = Milestone1_Test_Utility.sampleTask(testMilestone.Id);
@@ -77,34 +135,34 @@ private class Milestone1_Task_Chatter_Tst
         User userMain = Milestone1_Test_Utility.createSFUser();
         
         System.runAs(userMain) {
-        User userObj = Milestone1_Test_Utility.createSFUser();
-       
-        Milestone1_Test_Utility.createDefaultCustomChatterSettings(true);
-        
-        Milestone1_Project__c testProject = Milestone1_Test_Utility.sampleProject('UNIT TEST PROJECT NAME ABC123XYZ UNIQUE' + System.now());
-        insert testProject;
-        
-        Milestone1_Milestone__c testMilestone = Milestone1_Test_Utility.sampleMilestone(testProject.Id,null,'UNIT TEST MILESTONE NAME ACB123XYZ UNIQUE' + System.now());
-        insert testMilestone;
-        
-        Milestone1_Task__c testTask = Milestone1_Test_Utility.sampleTask(testMilestone.Id);
-        testTask.Assigned_To__c = UserInfo.getUserId();
-        testTask.Complete__c = false;
-        insert testTask;
-        
-        sObject subscription = Database.query('Select Id, ParentId, SubscriberId from EntitySubscription where ParentId = \''+testTask.Id+'\'');
-        //assert that the user is following this object
-        system.assertEquals(UserInfo.getUserId(),(id)subscription.get('SubscriberId'));
-        system.debug('Other User Id == ' + userObj.Id + 'Task Assigned Id ==' + testTask.Assigned_To__c);
-        testTask.Assigned_To__c = userObj.Id;
-        update testTask;
-        
-        List<sObject> subscriptionList = Database.query('Select Id, ParentId, SubscriberId from EntitySubscription where ParentId = \''+testTask.Id+'\' and SubscriberId = \''+UserInfo.getUserId()+'\'');
-        //assert that no one is following this object after its marked as complete
-        system.assertEquals(0,subscriptionList.size());
+	        User userObj = Milestone1_Test_Utility.createSFUser();
+	       
+	        Milestone1_Test_Utility.createDefaultCustomChatterSettings(true);
+	        
+	        insert testProject;
+	        
+	        Milestone1_Milestone__c testMilestone = Milestone1_Test_Utility.sampleMilestone(testProject.Id,null,'UNIT TEST MILESTONE NAME ACB123XYZ UNIQUE' + System.now());
+	        insert testMilestone;
+	        
+	        Milestone1_Task__c testTask = Milestone1_Test_Utility.sampleTask(testMilestone.Id);
+	        testTask.Assigned_To__c = UserInfo.getUserId();
+	        testTask.Complete__c = false;
+	        insert testTask;
+	        
+	        sObject subscription = Database.query('Select Id, ParentId, SubscriberId from EntitySubscription where ParentId = \''+testTask.Id+'\'');
+	        //assert that the user is following this object
+	        system.assertEquals(UserInfo.getUserId(),(id)subscription.get('SubscriberId'));
+	        system.debug('Other User Id == ' + userObj.Id + 'Task Assigned Id ==' + testTask.Assigned_To__c);
+	        testTask.Assigned_To__c = userObj.Id;
+	        update testTask;
+	        
+	        List<sObject> subscriptionList = Database.query('Select Id, ParentId, SubscriberId from EntitySubscription where ParentId = \''+testTask.Id+'\' and SubscriberId = \''+UserInfo.getUserId()+'\'');
+	        //assert that no one is following this object after its marked as complete
+	        system.assertEquals(0,subscriptionList.size());
         }
         
     }
-    
+
+/*******************	END CLASS	******************/    
 
 }

--- a/src/classes/Milestone1_Task_Chatter_Tst.cls-meta.xml
+++ b/src/classes/Milestone1_Task_Chatter_Tst.cls-meta.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ApexClass xmlns="http://soap.sforce.com/2006/04/metadata">
-    <apiVersion>20.0</apiVersion>
+    <apiVersion>28.0</apiVersion>
     <status>Active</status>
 </ApexClass>

--- a/src/classes/Milestone1_Task_Trigger_Utility.cls
+++ b/src/classes/Milestone1_Task_Trigger_Utility.cls
@@ -39,11 +39,17 @@ public class Milestone1_Task_Trigger_Utility {
         
         List<sObject> existingSubscriptions = new List<sObject>();
         //Retrieve existing list of Subscriptions for the Task(s) and store in Map by User. Salesforce does not allow user to subscribe to same object more than once so we can store in map.
-        if(Milestone1_Schema_Helper.isOrgChatterEnabled()){
+
+		/****************************************************************************************************
+	    /*  Author:   Passage Technology (www.passagetech.com)                      						*
+	    /*  Issue:    https://github.com/ForceDotComLabs/Milestones-PM/issues/75							*
+	    /*  Comment:  LIMIT clause is required when querying the EntitySubscription object.					*
+	    /****************************************************************************************************/         
+	    if(Milestone1_Schema_Helper.isOrgChatterEnabled()){
         	String queryString = 'Select Id, ParentId, SubscriberId from EntitySubscription where ParentId in (';
 	        for(Id recId:recIds)
 	        	queryString += '\''+recId+'\',';
-	        queryString = queryString.substring(0,queryString.length()-1) + ')'; //trim the trailing comma 
+	        queryString = queryString.substring(0,queryString.length()-1) + ') LIMIT 1000'; //trim the trailing comma 
 	        existingSubscriptions= Database.query(queryString);
         }
         //Create a Map of Users to Subscriptions
@@ -69,6 +75,7 @@ public class Milestone1_Task_Trigger_Utility {
                 
                 AutoChatterSetting chatterSettings = new AutoChatterSetting(rec.Assigned_To__c, rec.Assigned_To__r.ProfileId);
                 //If the custom setting for automatically following is true, lets perform auto chatter logic
+                
                 if(chatterSettings.autoFollow)
                 {
                     //If the there is not an existing subscription for the user, go ahead and follow the object. This prevents DUPLICATE_VALUE exception on subscription insert.
@@ -89,7 +96,6 @@ public class Milestone1_Task_Trigger_Utility {
             //Lets remove the previous Assigned To Follower if oldRec exists, and if the Assignment changed to another user.
             if(oldRec != null && oldRec.Assigned_To__c != null && oldRec.Assigned_To__c != rec.Assigned_To__c)
             {
-                system.debug('Unfollow..');
                 AutoChatterSetting chatterSettings = new AutoChatterSetting(oldRec.Assigned_To__c, oldRec.Assigned_To__r.ProfileId);
                 List<sObject> existingSubscriptionList = userSubscriptionMap.get(oldRec.Assigned_To__c);
                 sObject existingSubscription = getSubscriptionForUserAndRec(oldRec,existingSubscriptionList,userSubscriptionMap);

--- a/src/classes/Milestone1_Test_Utility.cls
+++ b/src/classes/Milestone1_Test_Utility.cls
@@ -119,7 +119,7 @@ public with sharing class Milestone1_Test_Utility {
         rec.Last_Email_Received__c = Datetime.now();
         return rec;     
     }
-    
+     
     public static Milestone1_Task__c sampleTask(Id milestoneId,Id PredecessorTaskId,Date kickoff, Date deadline){
         Milestone1_Task__c rec = new Milestone1_Task__c();
         rec.Project_Milestone__c = milestoneId;
@@ -322,6 +322,34 @@ public with sharing class Milestone1_Test_Utility {
                  profileUsed = p;
              }
         }
+        String namePrefix = ret;
+    
+         User testUser = new User();
+         testUser.Email = 'test@test.com';
+         testUser.Username = ret + '@testuser.com';
+         testUser.LastName = 'test';
+         testUser.Alias = 'test';
+         testUser.ProfileId = profileUsed.Id;
+         testUser.LanguageLocaleKey = 'en_US';
+         testUser.LocaleSidKey = 'en_US';
+         testUser.TimeZoneSidKey = 'America/Chicago';
+         testUser.EmailEncodingKey = 'UTF-8';
+        
+         insert testUser;  
+         
+         return testUser;
+  } 
+  
+	/****************************************************************************************************
+    /*  Author: Passage Technology (www.passagetech.com)                      							*
+    /*  Method:	createSFUser(Profile):  Enable dynamic assignment of a profile to enable testing with 	*
+    /*			a non-admin profile.																	*
+    /****************************************************************************************************/         
+  
+ public static User createSFUser(Profile profileUsed){
+    
+        
+        String ret = 'word' + math.rint(math.random() * 100000);
         String namePrefix = ret;
     
          User testUser = new User();


### PR DESCRIPTION
Added a unit test for a non-admin user to update a task and resolved an issue with a query() call on the EntitySubscription object without a LIMIT clause in the Task trigger handler.  A LIMIT clause is required on EntitySubscription for non-admin users.
https://github.com/ForceDotComLabs/Milestones-PM/issues/75
